### PR TITLE
feature, trigger effects without input

### DIFF
--- a/src/domino/core.cljc
+++ b/src/domino/core.cljc
@@ -3,7 +3,8 @@
     [domino.effects :as effects]
     [domino.graph :as graph]
     [domino.model :as model]
-    [domino.validation :as validation]))
+    [domino.validation :as validation]
+    [domino.util :as util]))
 
 (defn initialize
   "Takes a schema of :model, :events, and :effects
@@ -29,14 +30,9 @@
          events (model/connect-events model events)]
      {::model        model
       ::events       events
-      ::events-by-id (reduce
-                       (fn [events-by-id event]
-                         (if-let [id (:id event)]
-                           (assoc events-by-id id event)
-                           events-by-id))
-                       {}
-                       events)
+      ::events-by-id (util/map-by-id events)
       ::effects      (effects/effects-by-paths (model/connect-effects model effects))
+      ::effects-by-id (util/map-by-id effects)
       ::db           initial-db
       ::graph        (graph/gen-ev-graph events)})))
 
@@ -55,3 +51,10 @@
   Accepts the context, and a collection of event ids"
   [ctx event-ids]
   (transact ctx (graph/events-inputs-as-changes ctx event-ids)))
+
+(defn trigger-effects
+  "Triggers effects by ids as opposed to data changes
+
+  Accepts the context, and a collection of effect ids"
+  [ctx effect-ids]
+  (transact ctx (graph/effect-outputs-as-changes ctx effect-ids)))

--- a/src/domino/graph.cljc
+++ b/src/domino/graph.cljc
@@ -247,3 +247,20 @@
                      inputs))))
     []
     event-ids))
+
+(defn try-effect [{:keys [handler] :as effect} ctx db old-outputs]
+  (try
+    (handler ctx old-outputs)
+    (catch #?(:clj Exception :cljs js/Error) e
+      (throw (ex-info "failed to execute effect" {:effect effect :context ctx :db db} e)))))
+
+(defn effect-outputs-as-changes [{:domino.core/keys [effects-by-id db model] :as ctx} effect-ids]
+  (let [id->effect  #(get-in effects-by-id [%])
+        res->change (juxt (comp vector first) second)
+        old-outputs #(get-db-paths model db (map vector (:outputs %)))
+        run-effect  #(try-effect % ctx db (old-outputs %))]
+    (->> effect-ids
+         (map id->effect)
+         (map run-effect)
+         (mapcat identity)
+         (map res->change))))              

--- a/src/domino/util.cljc
+++ b/src/domino/util.cljc
@@ -8,3 +8,9 @@
     (if (not-empty path)
       (recur (conj paths (vec path)) (drop-last path))
       paths)))
+
+(defn map-by-id [items]
+  (->> items
+       (filter #(contains? % :id))
+       (map (juxt :id identity))    
+       (into {})))

--- a/test/domino/core_test.cljc
+++ b/test/domino/core_test.cljc
@@ -78,6 +78,16 @@
                         {:n 10 :m 0})]
     (is (= {:n 10 :m 10} (:domino.core/db (trigger-events ctx [:match-n]))))))
 
+(deftest trigger-effects-without-input
+  (let [ctx (initialize {:model  [[:n {:id :n}]
+                                       [:m {:id :m}]]
+                              :effects [{:id      :match-n
+                                         :outputs [:m :n]
+                                         :handler (fn [_ {:keys [n]}]
+                                                    {:m n})}]}
+                             {:n 10 :m 0})]
+    (is (= {:n 10 :m 10} (:domino.core/db (trigger-effects ctx [:match-n]))))))
+
 (deftest pre-post-interceptors
   (let [result (atom nil)
         ctx    (initialize {:model   [[:foo {:id  :foo


### PR DESCRIPTION
A new feature to explicitly trigger effects with no inputs.
see: #6

As suggested by @yogthos
Do not trigger events but effects.
#6 (comment)