### PR TITLE
replace async callback API with derefable returns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### 0.3.3
+
+- **[BREAKING]** replaced async callback API (`:async? true` + 4-arg handler with callback) with derefable returns; async handlers now return `delay`/`future`/`promise` and the engine auto-derefs
+- on the JVM, `future` and `promise` block until resolved; in ClojureScript, `delay` is supported for lazy computation — truly async operations should use effects
+- the `:async?` flag is silently ignored for backward compatibility
+
 ### 0.3.2
 
 - - **[BREAKING]** namespaced `:change-history` key as `:domino.core/change-history`

--- a/README.md
+++ b/README.md
@@ -58,18 +58,21 @@ The macro requires that the `:keys` destructuring syntax is used for input and o
 expands the the event map with the `:inputs` and `:outputs` keys being inferred from the
 ones specified using the `:keys` in the event declaration.
 
-It's also possible to declare async events by providing the `:async?` key, e.g:
+Event handlers can return derefable values for lazy or async computation.
+The engine automatically detects and derefs the result before applying it:
 
 ```clojure
-{:async?  true
- :inputs  [:amount]
+{:inputs  [:amount]
  :outputs [:total]
- :handler (fn [ctx {:keys [amount]} {:keys [total]} callback]
-            (callback {:total (+ total amount)}))}
+ :handler (fn [ctx {:keys [amount]} {:keys [total]}]
+            (delay {:total (+ total amount)}))}
 ```
 
-Async event handler takes an additional argument that specifies the callback function
-that should be called with the result.
+Any type implementing `IDeref` is supported. On the JVM this includes `delay`, `future`,
+and `promise` — the engine will block until the result is available. In ClojureScript,
+`delay` can be used for lazy/memoized computation. Truly async operations (e.g. API calls)
+should be handled outside the transaction via effects: trigger a side effect, then transact
+the result back when it arrives.
 
 ### 3. Effects
 

--- a/src/domino/model.cljc
+++ b/src/domino/model.cljc
@@ -64,13 +64,13 @@
     (not pre)
     (let [post (wrap-post post)]
       (fn [ctx inputs outputs]
-        (post (handler ctx inputs outputs))))
+        (post (util/resolve-result (handler ctx inputs outputs)))))
 
     :else
     (let [handler (wrap-pre handler pre)
           post    (wrap-post post)]
       (fn [ctx inputs outputs]
-        (post (handler ctx inputs outputs))))))
+        (post (util/resolve-result (handler ctx inputs outputs)))))))
 
 (defn ids-to-interceptors
   "finds the interceptors based on the provided ids

--- a/src/domino/util.cljc
+++ b/src/domino/util.cljc
@@ -14,3 +14,13 @@
 
 (defn map-by-id [items]
   (into {} (comp (filter :id) (map (juxt :id identity))) items))
+
+(defn resolve-result
+  "If x is derefable (delay, future, promise, atom), derefs it.
+  Otherwise returns x as-is."
+  [x]
+  (if (and (some? x)
+           #?(:clj  (instance? clojure.lang.IDeref x)
+              :cljs (satisfies? IDeref x)))
+    (deref x)
+    x))

--- a/test/domino/async.clj
+++ b/test/domino/async.clj
@@ -3,28 +3,102 @@
     [domino.core :as core]
     [clojure.test :refer :all]))
 
-(deftest async-handler-test
+(deftest basic-delay-handler
+  (let [ctx (core/initialize
+              {:model  [[:foo {:id :foo}]
+                        [:bar {:id :bar}]]
+               :events [{:inputs  [:foo]
+                         :outputs [:bar]
+                         :handler (fn [_ {:keys [foo]} _]
+                                    (delay {:bar (inc foo)}))}]})]
+    (is (= {:foo 1 :bar 2}
+           (:domino.core/db (core/transact ctx [[[:foo] 1]]))))))
+
+(deftest cascading-async-handlers
   (let [result (atom nil)
-        ctx    (core/initialize {:model   [[:foo {:id :foo}]
-                                           [:bar {:id :bar}]
-                                           [:baz {:id :baz}]
-                                           [:buz {:id :buz}]]
-                                 :events  [{:async? true
-                                            :inputs  [:foo]
-                                            :outputs [:bar]
-                                            :handler (fn [ctx {:keys [foo]} _ cb]
-                                                       (cb {:bar (inc foo)}))}
-                                           {:async? true
-                                            :inputs  [:bar]
-                                            :outputs [:baz]
-                                            :handler (fn [ctx {:keys [bar]} _ cb]
-                                                       (cb {:baz (inc bar)}))}
-                                           {:inputs  [:baz]
-                                            :outputs [:buz]
-                                            :handler (fn [ctx {:keys [baz]} _]
-                                                       {:buz (inc baz)})}]
-                                 :effects [{:inputs  [:buz]
-                                            :handler (fn [ctx {:keys [buz]}]
-                                                       (reset! result buz))}]})]
+        ctx    (core/initialize
+                 {:model   [[:foo {:id :foo}]
+                            [:bar {:id :bar}]
+                            [:baz {:id :baz}]
+                            [:buz {:id :buz}]]
+                  :events  [{:inputs  [:foo]
+                             :outputs [:bar]
+                             :handler (fn [_ {:keys [foo]} _]
+                                        (delay {:bar (inc foo)}))}
+                            {:inputs  [:bar]
+                             :outputs [:baz]
+                             :handler (fn [_ {:keys [bar]} _]
+                                        (delay {:baz (inc bar)}))}
+                            {:inputs  [:baz]
+                             :outputs [:buz]
+                             :handler (fn [_ {:keys [baz]} _]
+                                        {:buz (inc baz)})}]
+                  :effects [{:inputs  [:buz]
+                             :handler (fn [_ {:keys [buz]}]
+                                        (reset! result buz))}]})]
     (:domino.core/db (core/transact ctx [[[:foo] 1]]))
     (is (= 4 @result))))
+
+(deftest mixed-sync-async-handlers
+  (let [ctx (core/initialize
+              {:model  [[:a {:id :a}]
+                        [:b {:id :b}]
+                        [:c {:id :c}]]
+               :events [{:inputs  [:a]
+                         :outputs [:b]
+                         :handler (fn [_ {:keys [a]} _]
+                                    (delay {:b (inc a)}))}
+                        {:inputs  [:b]
+                         :outputs [:c]
+                         :handler (fn [_ {:keys [b]} _]
+                                    {:c (* b 10)})}]})]
+    (is (= {:a 1 :b 2 :c 20}
+           (:domino.core/db (core/transact ctx [[[:a] 1]]))))))
+
+(deftest nil-via-delay-keeps-old-outputs
+  (let [ctx (core/initialize
+              {:model  [[:a {:id :a}]
+                        [:b {:id :b}]]
+               :events [{:inputs  [:a]
+                         :outputs [:b]
+                         :handler (fn [_ _ _]
+                                    (delay nil))}]}
+              {:b 42})]
+    (is (= {:a 1 :b 42}
+           (:domino.core/db (core/transact ctx [[[:a] 1]]))))))
+
+(deftest future-handler
+  (let [ctx (core/initialize
+              {:model  [[:foo {:id :foo}]
+                        [:bar {:id :bar}]]
+               :events [{:inputs  [:foo]
+                         :outputs [:bar]
+                         :handler (fn [_ {:keys [foo]} _]
+                                    (future {:bar (* foo 10)}))}]})]
+    (is (= {:foo 5 :bar 50}
+           (:domino.core/db (core/transact ctx [[[:foo] 5]]))))))
+
+(deftest error-propagation-from-delay
+  (is (thrown-with-msg?
+        clojure.lang.ExceptionInfo
+        #"failed to execute event"
+        (let [ctx (core/initialize
+                    {:model  [[:a {:id :a}]
+                              [:b {:id :b}]]
+                     :events [{:inputs  [:a]
+                               :outputs [:b]
+                               :handler (fn [_ _ _]
+                                          (delay (throw (ex-info "boom" {}))))}]})]
+          (core/transact ctx [[[:a] 1]])))))
+
+(deftest backward-compat-async-flag-ignored
+  (let [ctx (core/initialize
+              {:model  [[:foo {:id :foo}]
+                        [:bar {:id :bar}]]
+               :events [{:async?  true
+                         :inputs  [:foo]
+                         :outputs [:bar]
+                         :handler (fn [_ {:keys [foo]} _]
+                                    (delay {:bar (inc foo)}))}]})]
+    (is (= {:foo 1 :bar 2}
+           (:domino.core/db (core/transact ctx [[[:foo] 1]]))))))

--- a/test/domino/util_test.cljc
+++ b/test/domino/util_test.cljc
@@ -19,3 +19,9 @@
   (is (= {} (util/map-by-id [{:name "no id"}])))
   (is (= {:a {:id :a :name "A"}} (util/map-by-id [{:id :a :name "A"}])))
   (is (= {:a {:id :a} :b {:id :b}} (util/map-by-id [{:id :a} {:name "no id"} {:id :b}]))))
+
+(deftest resolve-result-test
+  (is (= {:b 1} (util/resolve-result {:b 1})))
+  (is (nil? (util/resolve-result nil)))
+  (is (= {:b 1} (util/resolve-result (delay {:b 1}))))
+  (is (= {:b 1} (util/resolve-result (atom {:b 1})))))


### PR DESCRIPTION
The callback-based async event system was fundamentally broken: return values were lost by reduce, and the extra callback arg caused arity errors with interceptor-wrapped handlers. Async handlers now return derefable values (delay, future, promise) that the engine auto-derefs. On the JVM this supports truly async via future/promise; in ClojureScript delay is supported for lazy computation while truly async operations should use effects. The :async? flag is silently ignored for backward compatibility.